### PR TITLE
Add JWT to authorize requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,15 @@ async-stream = "0.3"
 base64 = "0.10"
 bigdecimal = { version = "0.2", features = [ "serde" ] }
 chrono = { version = "0.4", features = [ "serde" ] }
+coarsetime = "0.1.36"
+elliptic-curve = { version = "0.13.8", default-features = false, features = ["hazmat", "sec1"] }
 futures = "0.3"
 hmac = "0.7"
 http = "0.2"
 hyper = { version = "0.14", features = [ "full" ] }
 hyper-tls = "0.5"
+jwt-simple = { version = "0.12.12", default-features = false, features = ["pure-rust"] }
+p256 = { version = "0.13.2", features = ["ecdsa", "std", "pkcs8", "pem"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/src/private.rs
+++ b/src/private.rs
@@ -29,10 +29,7 @@ impl Private {
     /// https://developers.coinbase.com/api/v2#list-accounts
     ///
     pub fn accounts<'a>(&'a self) -> impl Stream<Item = Result<Vec<Account>>> + 'a {
-        let limit = 100;
-        let uri = UriTemplate::new("/v2/accounts{?query*}")
-            .set("query", &[("limit", limit.to_string().as_ref())])
-            .build();
+        let uri = UriTemplate::new("/v2/accounts").build();
         let request = self.request(&uri);
         self._pub.get_stream(request)
     }

--- a/src/public.rs
+++ b/src/public.rs
@@ -226,11 +226,6 @@ pub struct CurrencyPrice {
     pub currency: String,
 }
 
-#[derive(Deserialize)]
-struct CurrentTime {
-    iso: DateTime,
-}
-
 #[cfg(test)]
 mod test {
     use bigdecimal::FromPrimitive;
@@ -303,18 +298,5 @@ mod test {
             BigDecimal::from_f32(1010.25).unwrap()
         );
         assert_eq!(currency_price.currency, "USD");
-    }
-
-    #[test]
-    fn test_current_time_deserialize() {
-        let input = r#"
-    {
-    "iso": "2015-06-23T18:02:51Z",
-    "epoch": 1435082571
-    }"#;
-        let time: crate::DateTime = serde_json::from_slice(input.as_bytes())
-            .map(|c: CurrentTime| c.iso)
-            .unwrap();
-        assert_eq!(1435082571, time.timestamp());
     }
 }


### PR DESCRIPTION
Coinbase now requires JWT token in request headers. This PR updates the request builder to generate a JWT and pass it in the Authorization header of a request. It depends indirectly on zeroize version that conflicts with solana 1.18.26 dependencies.  I’ll make corresponding PRs in jup-ag and sys repositories soon.